### PR TITLE
Read HOST and PORT from environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ dist
 .yarn/install-state.gz
 .pnp.*
 build/
+.tap/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ The application is developed and tested against the current Node.js LTS (v22).
 - `npm start` – run the compiled server.
 - `npm test` – build the project and run integration tests with `tap`.
 
+## Configuration
+
+The server listens on the host and port specified by the environment variables:
+
+- `HOST` – defaults to `0.0.0.0`.
+- `PORT` – defaults to `3000`.
+
+For example:
+
+```bash
+HOST=127.0.0.1 PORT=8080 npm start
+```
+
+will start the server on `http://127.0.0.1:8080`.
+
 ## Endpoints
 
 ### `POST /workflows`

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,7 +57,9 @@ server.post<{ Params: { id: string }; Body: { input?: any } }>('/workflows/:id/r
 export default server;
 
 if (require.main === module) {
-  server.listen({ port: 3000, host: '0.0.0.0' }).catch(err => {
+  const port = parseInt(process.env.PORT ?? '3000', 10);
+  const host = process.env.HOST ?? '0.0.0.0';
+  server.listen({ port, host }).catch(err => {
     server.log.error(err);
     process.exit(1);
   });

--- a/test/server-start.test.ts
+++ b/test/server-start.test.ts
@@ -1,0 +1,17 @@
+import tap from 'tap';
+import server from '../src/server';
+
+// start the server on an ephemeral port to verify it can be configured
+// at runtime.
+tap.test('start server on custom port', async t => {
+  const address = await server.listen({ port: 0, host: '127.0.0.1' });
+  t.ok(address, 'server started');
+  const port = (server.server.address() as any).port;
+  t.ok(port, 'port detected');
+  t.ok(port !== 3000, 'uses non-default port');
+
+  const res = await fetch(`http://127.0.0.1:${port}/workflows`);
+  t.equal(res.status, 200, 'server responded');
+
+  await server.close();
+});


### PR DESCRIPTION
## Summary
- read `HOST` and `PORT` from `process.env`
- describe `HOST` and `PORT` in the README
- test starting the server with a custom port
- ignore `.tap` test artifacts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684707e89088832c845046fc8b9b88fb