### PR TITLE
Add persistent workflow storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This project provides a simple Fastify server written in TypeScript that allows 
 
 The application is developed and tested against the current Node.js LTS (v22).
 
+Workflow configurations are persisted on disk. The directory can be customised
+using the `WORKFLOWS_DIR` environment variable (defaults to `./data`).
+
 ## Scripts
 
 - `npm run dev` – start the server in development using `ts-node-dev`.

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,43 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { WorkflowConfig } from 'rootsby/types';
+
+export default class WorkflowStorage {
+  constructor(private dir: string) {
+    // directory will be created on demand
+  }
+
+  private filePath(id: string) {
+    return path.join(this.dir, `${id}.json`);
+  }
+
+  async save(workflow: WorkflowConfig): Promise<void> {
+    await fs.mkdir(this.dir, { recursive: true });
+    await fs.writeFile(this.filePath(workflow.id), JSON.stringify(workflow, null, 2), 'utf8');
+  }
+
+  async get(id: string): Promise<WorkflowConfig | undefined> {
+    try {
+      const data = await fs.readFile(this.filePath(id), 'utf8');
+      return JSON.parse(data);
+    } catch (err: any) {
+      if (err && err.code === 'ENOENT') {
+        return undefined;
+      }
+      throw err;
+    }
+  }
+
+  async list(): Promise<WorkflowConfig[]> {
+    await fs.mkdir(this.dir, { recursive: true });
+    const files = await fs.readdir(this.dir);
+    const result: WorkflowConfig[] = [];
+    for (const file of files) {
+      if (file.endsWith('.json')) {
+        const data = await fs.readFile(path.join(this.dir, file), 'utf8');
+        result.push(JSON.parse(data));
+      }
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- persist workflow configs on disk with a storage class
- switch server endpoints to use the new storage
- document storage directory
- test persistence across server instances

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847081d345c832cb8ade81101c5631f