### PR TITLE
Rename workflow test

### DIFF
--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -129,7 +129,7 @@ tap.test("reject invalid run payload", async (t) => {
       t.equal(getRes.json().name, "updated", "workflow replaced");
     });
 
-    tap.test("delete workflow", async (t) => {
+    tap.test("get workflow after update", async (t) => {
       const getRes = await server.inject({
         method: "GET",
         url: `/workflows/${config.id}`,


### PR DESCRIPTION
## Summary
- rename misleading subtest name in workflow tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68471a9464a4832c9a6c30be22684c39