### PR TITLE
Fix PUT 404 handling

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -69,13 +69,9 @@ server.put<{ Params: { id: string }; Body: CreateWorkflowBody }>("/workflows/:id
     return reply.code(400).send({ error: "config id mismatch" });
   }
   const workflow = await storage.get(id);
-  // This beaks tests
-  // if (!workflow) {
-  //   return reply.code(404).send({ error: "not found" });
-  // }
-  // if (workflow.id !== id) {
-  //   return reply.code(404).send({ error: "not found" });
-  // }
+  if (!workflow) {
+    return reply.code(404).send({ error: "not found" });
+  }
   await storage.save(config);
   // workflow.set(id, config);
   return await storage.get(id);

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -65,6 +65,20 @@ tap.test("create and run workflow", async (t) => {
   await server.close();
 });
 
+tap.test("update missing workflow returns 404", async (t) => {
+  const dir = t.testdir();
+  const srv = createServer(dir);
+  const missingId = crypto.randomUUID();
+  const missingConfig = { ...config, id: missingId };
+  const res = await srv.inject({
+    method: "PUT",
+    url: `/workflows/${missingId}`,
+    payload: { config: missingConfig },
+  });
+  t.equal(res.statusCode, 404, "update rejected for missing workflow");
+  await srv.close();
+});
+
 tap.test("reject invalid workflow creation", async (t) => {
   const res = await server.inject({
     method: "POST",


### PR DESCRIPTION
## Summary
- ensure workflow exists before updating in `PUT /workflows/:id`
- test 404 on updating a missing workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68471ab5c558832c9e2acd121fe9e364